### PR TITLE
[gitpod] allow prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,10 +2,11 @@ ports:
 - port: 8000
   onOpen: open-preview
 tasks:
-- init: |
-    composer install
+- before: |
     php -r "file_exists('.env') || copy('.env.example', '.env');"
     url=$(gp url 8000); sed -i'' "s#^APP_URL=http://localhost*#APP_URL=$url\nASSET_URL=$url#g" .env  #change APP_URL and ASSET_URL to 8080 URL
-    php artisan key:generate --ansi
+  init: |
+    composer install
   command: |
+    php artisan key:generate --ansi
     php artisan serve


### PR DESCRIPTION
This PR moves out the url settings to `before` so it gets reevaluated on every workspace start.
When you enable prebuilds (btw. you should by installing the [GH App](https://www.gitpod.io/docs/prebuilds/#enable-prebuilt-workspaces)) the `init` task is not executed on every workspace start. 
So the url in `.env` would be wrong.

You can try open this PR in gitpod, to see prebuilds in action as I have enabled them on all my repositories.